### PR TITLE
Increase Chub API timeouts and add error handling

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -1,0 +1,74 @@
+"""Image generation module."""
+import os
+import sys
+import time
+import requests
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import config
+
+BASE_URL = config.BASE_URL
+HEADERS = {"Authorization": f"Bearer {config.STAGE_TOKEN}"}
+
+POLLING_INTERVAL = 10
+MAX_POLL_ATTEMPTS = 60
+REQUEST_TIMEOUT = 30
+
+
+def generate_face(prompt: str, reference_url: str | None = None) -> str | None:
+    """Generate an image URL for the given prompt.
+
+    If ``reference_url`` is provided the img2img endpoint is used. The
+    function polls the ``/check`` endpoint until the generation is
+    completed and returns the resulting image URL or ``None`` on failure.
+    """
+    endpoint = f"{BASE_URL}/images/text2img"
+    payload: dict[str, object] = {"prompt": prompt}
+
+    if reference_url:
+        endpoint = f"{BASE_URL}/images/img2img"
+        payload["parent_image"] = reference_url
+
+    try:
+        response = requests.post(
+            endpoint, headers=HEADERS, json=payload, timeout=REQUEST_TIMEOUT
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"Generation request failed: {exc}")
+        return None
+
+    data = response.json()
+    generation_uuid = data.get("generation_uuid")
+    if not generation_uuid:
+        return None
+
+    # poll for completion
+    for attempt in range(1, MAX_POLL_ATTEMPTS + 1):
+        print(f"Polling attempt {attempt}/{MAX_POLL_ATTEMPTS}...")
+        try:
+            check = requests.post(
+                f"{BASE_URL}/check",
+                headers=HEADERS,
+                json={"generation_uuid": generation_uuid},
+                timeout=REQUEST_TIMEOUT,
+            )
+            check.raise_for_status()
+            result = check.json()
+        except requests.RequestException as exc:
+            print(f"Check request failed: {exc}")
+            result = {}
+
+        status = result.get("status") or result.get("state")
+        if status == "completed":
+            url = result.get("image_url") or result.get("url")
+            if not url and isinstance(result.get("images"), list):
+                images = result["images"]
+                if images:
+                    first = images[0]
+                    url = first.get("url") if isinstance(first, dict) else first
+            return url
+        if status in {"failed", "error"}:
+            return None
+        time.sleep(POLLING_INTERVAL + attempt * 2)
+    return None

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,71 @@
+"""Main orchestration loop for the face refinement system."""
+from __future__ import annotations
+
+import csv
+import json
+import os
+import time
+from datetime import datetime
+
+from generator import generate_face
+from verifier import verify_match
+from refiner import refine_prompt
+
+TARGET_DESCRIPTION = (
+    "Professional man with sharp jawline, bright blue eyes, short brown hair,"
+    " slight smile, clean shaven."
+)
+INITIAL_PROMPT = (
+    "photorealistic portrait of a professional man with sharp angular jawline,"
+    " bright blue eyes, short brown hair, subtle smile, clean shaven face, studio lighting"
+)
+THRESHOLD = 0.85
+MAX_ITERATIONS = 10
+
+
+def main() -> None:
+    prompt = INITIAL_PROMPT
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    csv_path = os.path.join("data", f"run_{timestamp}.csv")
+
+    with open(csv_path, "w", newline="") as csvfile:
+        fieldnames = ["iteration", "prompt", "image_url", "match_score", "errors"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for iteration in range(1, MAX_ITERATIONS + 1):
+            print(f"Iteration {iteration}: generating image...")
+            image_url = generate_face(prompt)
+            if not image_url:
+                print("Image generation failed. Stopping.")
+                break
+
+            result = verify_match(image_url, TARGET_DESCRIPTION)
+            match_score = result.get("match_score", 0.0)
+            errors = result.get("errors", {})
+
+            writer.writerow(
+                {
+                    "iteration": iteration,
+                    "prompt": prompt,
+                    "image_url": image_url,
+                    "match_score": match_score,
+                    "errors": json.dumps(errors),
+                }
+            )
+            csvfile.flush()
+
+            print(f"Score: {match_score:.2f}")
+            if match_score >= THRESHOLD:
+                print("Target achieved!" )
+                break
+
+            prompt = refine_prompt(prompt, errors)
+            print(f"Refined prompt: {prompt}")
+            time.sleep(2)  # rate limiting
+
+    print(f"Results saved to {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/refiner.py
+++ b/src/refiner.py
@@ -1,0 +1,52 @@
+"""Prompt refinement module."""
+import os
+import sys
+import json
+import requests
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import config
+
+BASE_URL = config.BASE_URL
+HEADERS = {"Authorization": f"Bearer {config.STAGE_TOKEN}"}
+
+REQUEST_TIMEOUT = 30
+
+
+def refine_prompt(current_prompt: str, errors: dict) -> str:
+    """Return an improved prompt based on mismatch errors."""
+    instruction = (
+        "You refine prompts for an image generation model focused on human faces."
+        " Given the current prompt and a dictionary of errors describing missing or"
+        " incorrect facial features, return an improved prompt."
+    )
+    user_content = (
+        f"Current prompt: {current_prompt}\nErrors: {json.dumps(errors)}\n"
+        "Return only the improved prompt."
+    )
+    payload = {
+        "model": "mistral",
+        "messages": [
+            {"role": "system", "content": instruction},
+            {"role": "user", "content": user_content},
+        ],
+    }
+    try:
+        response = requests.post(
+            f"{BASE_URL}/v1/chat/completions",
+            headers=HEADERS,
+            json=payload,
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"Refinement request failed: {exc}")
+        return current_prompt
+
+    return (
+        response.json()
+        .get("choices", [{}])[0]
+        .get("message", {})
+        .get("content", current_prompt)
+        .strip()
+    )

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -1,0 +1,56 @@
+"""Image verification module."""
+import os
+import sys
+import json
+import requests
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import config
+
+BASE_URL = config.BASE_URL
+HEADERS = {"Authorization": f"Bearer {config.STAGE_TOKEN}"}
+
+REQUEST_TIMEOUT = 30
+
+
+def verify_match(image_url: str, target_description: str) -> dict:
+    """Return match score and errors for the image against a description."""
+    # Prepare OpenAI-style payload
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "You are a vision model that evaluates how well an image matches a"
+                        " target description. Respond strictly as JSON with keys 'match_score'"
+                        " (0-1 float) and 'errors' (dict). Target description: "
+                        f"{target_description}"
+                    ),
+                },
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ],
+        }
+    ]
+    payload = {"model": "mistral", "messages": messages}
+
+    try:
+        response = requests.post(
+            f"{BASE_URL}/v1/chat/completions",
+            headers=HEADERS,
+            json=payload,
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        return {"match_score": 0.0, "errors": {"api": f"verification failed: {exc}"}}
+
+    content = (
+        response.json().get("choices", [{}])[0].get("message", {}).get("content", "")
+    )
+    try:
+        data = json.loads(content)
+    except Exception:
+        data = {"match_score": 0.0, "errors": {"parse": "invalid JSON"}}
+    return data

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import time
+import requests
+
+# ensure project root on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import config
+
+BASE_URL = config.BASE_URL
+HEADERS = {"Authorization": f"Bearer {config.STAGE_TOKEN}"}
+REQUEST_TIMEOUT = 30
+
+
+def test_image_generation_endpoint():
+    start = time.time()
+    response = requests.post(
+        f"{BASE_URL}/images/text2img",
+        headers=HEADERS,
+        json={"prompt": "test face", "width": 512, "height": 512},
+        timeout=REQUEST_TIMEOUT,
+    )
+    duration = time.time() - start
+    assert response.status_code == 200
+    data = response.json()
+    assert "generation_uuid" in data
+    print(f"/images/text2img responded in {duration:.2f}s")
+
+
+def test_chat_completion_endpoint():
+    start = time.time()
+    response = requests.post(
+        f"{BASE_URL}/v1/chat/completions",
+        headers=HEADERS,
+        json={
+            "model": "mistral",
+            "messages": [{"role": "user", "content": "Say hello"}],
+        },
+        timeout=REQUEST_TIMEOUT,
+    )
+    duration = time.time() - start
+    assert response.status_code == 200
+    data = response.json()
+    assert "choices" in data
+    print(f"/v1/chat/completions responded in {duration:.2f}s")


### PR DESCRIPTION
## Summary
- expand image generation polling to 60 attempts with 10s interval, exponential backoff, and 30s request timeouts
- wrap generator, verifier, and refiner API calls in try/except for clearer error reporting
- apply consistent request timeout in endpoint tests

## Testing
- `python -c "from src.generator import generate_face; print(generate_face('simple face test'))"` *(fails: ModuleNotFoundError: No module named 'config')*
- `MAX_ITERATIONS=2 python src/main.py` *(fails: ModuleNotFoundError: No module named 'config')*
- `pytest tests/test_endpoints.py -q` *(fails: ModuleNotFoundError: No module named 'config')*


------
https://chatgpt.com/codex/tasks/task_e_6897960ed70c8332b6ea12be1d848b11